### PR TITLE
[DP-126] JetStore Fix: Remove leading Byte Order Mark (BOM) in csv files

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -54,6 +54,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.16.7
 	github.com/aws/aws-sdk-go-v2/service/sfn v1.16.1
 	github.com/badoux/checkmail v1.2.1
+	github.com/dimchansky/utfbom v1.1.1
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/mux v1.8.0
 	github.com/jackc/chunkreader/v2 v2.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -79,6 +79,8 @@ github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7Do
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dimchansky/utfbom v1.1.1 h1:vV6w1AhK4VMnhBno/TPVCoK9U/LP0PkLCS9tbxHdi/U=
+github.com/dimchansky/utfbom v1.1.1/go.mod h1:SxdoEBH5qIqFocHMyGOXVAybYJdr71b1Q/j0mACtrfE=
 github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vbaY=
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=

--- a/jets/loader/loader.go
+++ b/jets/loader/loader.go
@@ -27,6 +27,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
+	"github.com/dimchansky/utfbom"
 )
 
 // Command Line Arguments
@@ -433,14 +434,22 @@ func processFile(dbpool *pgxpool.Pool, fileHd, errFileHd *os.File) (*schema.Head
 		}
 		fmt.Println("Got argument: sep_flag", sep_flag)	
 
+		// Remove the Byte Order Mark (BOM) at beggining of the file if present
+		sr, enc := utfbom.Skip(fileHd)
+		fmt.Printf("Detected encoding: %s\n", enc)
+
 		// Setup a csv reader
-		csvReader = csv.NewReader(fileHd)
+		csvReader = csv.NewReader(sr)
 		csvReader.Comma = rune(sep_flag)
 		csvReader.ReuseRecord = true
 
 	case FixedWith:
+		// Remove the Byte Order Mark (BOM) at beggining of the file if present
+		sr, enc := utfbom.Skip(fileHd)
+		fmt.Printf("Detected encoding: %s\n", enc)
+
 		// Setup a fixed-width reader
-		fwScanner = bufio.NewScanner(fileHd)
+		fwScanner = bufio.NewScanner(sr)
 	}
 
 	// Setup a writer for error file (bad records)


### PR DESCRIPTION
## Change description

> Description here

## Type of change
- [X] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Documentation (adds/updates documentation)
- [ ] Refactor (code refactoring with no business impact)
- [ ] Chore (housekeeping tasks)

:warning: Be sure to add a matching label for your change type!

## Related task(s)
[DP-126] JetStore Fix: Remove leading Byte Order Mark (BOM) in csv files

> Link [#1]() 

## Checklists

### Development

- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines


[DP-126]: https://walrushealth.atlassian.net/browse/DP-126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ